### PR TITLE
Adjust wizard step layout

### DIFF
--- a/assets/css/roadmd.css
+++ b/assets/css/roadmd.css
@@ -347,3 +347,108 @@ input.severity-quantity::-webkit-outer-spin-button {
   stroke-width: 1.2 !important;
   transition: fill 0.1s, stroke-width 0.1s;
 }
+.step {
+    display: none;
+}
+
+.step-nav {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.step-nav .nav-item {
+    background: #eee;
+    padding: 6px 12px;
+    border-radius: 4px;
+}
+
+.step-nav .nav-item.active {
+    background: #007BFF;
+    color: #fff;
+}
+
+.navigation {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.navigation button {
+    width: 48%;
+}
+
+.navigation.justify-right {
+    justify-content: flex-end;
+}
+
+.navigation.justify-right button {
+    width: 48%;
+}
+
+.navigation.single {
+    justify-content: center;
+}
+
+.navigation.single button {
+    width: 48%;
+}
+
+.step1-grid {
+    display: flex;
+    gap: 20px;
+    margin-top: 20px;
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.step1-grid > div {
+    flex: 1;
+    text-align: center;
+}
+
+.road-length input {
+    width: 75%;
+    display: block;
+    margin: 0 auto;
+}
+
+.step1-grid label {
+    display: block;
+    margin-bottom: 8px;
+}
+
+.material-toggle {
+    display: flex;
+    justify-content: center;
+    margin-top: 8px;
+    border: 1px solid #ccc;
+    border-radius: 20px;
+    overflow: hidden;
+    width: max-content;
+    margin-left: auto;
+    margin-right: auto;
+    background: #f0f0f0;
+}
+
+.material-toggle input {
+    display: none;
+}
+
+.material-toggle label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 18px;
+    cursor: pointer;
+    flex: 1 1 50%;
+    text-align: center;
+    line-height: 1;
+}
+
+.material-toggle input:checked + label {
+    background: #007BFF;
+    color: #fff;
+}

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const steps = document.querySelectorAll('.step');
+    const navItems = document.querySelectorAll('.nav-item');
+
+    function showStep(n) {
+        steps.forEach((step, idx) => {
+            step.style.display = idx === n - 1 ? 'block' : 'none';
+        });
+        navItems.forEach((item, idx) => {
+            item.classList.toggle('active', idx === n - 1);
+        });
+    }
+
+    document.getElementById('to-step-2').addEventListener('click', () => showStep(2));
+    document.getElementById('back-to-step-1').addEventListener('click', () => showStep(1));
+    document.getElementById('diagnose-button').addEventListener('click', () => showStep(3));
+    document.getElementById('back-to-step-2').addEventListener('click', () => showStep(2));
+
+    showStep(1);
+});

--- a/pages/roadmd.html
+++ b/pages/roadmd.html
@@ -9,133 +9,92 @@
 </head>
 <body>
     <div id="header"></div>
-    
+
     <div id="symptom-checker">
-        <h2>RoadMD</h2>
+        <div class="step-nav">
+            <div class="nav-item" id="nav-step1">Step 1: Road Info</div>
+            <div class="nav-item" id="nav-step2">Step 2: Defects</div>
+            <div class="nav-item" id="nav-step3">Step 3: Results</div>
+        </div>
+
+        <div id="step-1" class="step">
+            <h2>RoadMD</h2>
+            <div class="step1-grid">
+                <div class="road-length">
+                    <label for="road-length-input">Road Length (m)</label>
+                    <input type="number" id="road-length-input" placeholder="Enter road length in meters">
+                </div>
+                <div class="road-material">
+                    <label for="material-asphalt">Road Material</label>
+                    <div class="material-toggle">
+                        <input type="radio" id="material-asphalt" name="road-material" value="asphalt" checked>
+                        <label for="material-asphalt">Asphalt</label>
+                        <input type="radio" id="material-concrete" name="road-material" value="concrete">
+                        <label for="material-concrete">Concrete</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="navigation single">
+                <button id="to-step-2">Continue</button>
+            </div>
+        </div>
+
+    <div id="step-2" class="step">
+        <h2>Select Defects</h2>
         <input type="text" id="symptom-input" placeholder="Enter road defects...">
         <div id="autocomplete-list" class="autocomplete-list"></div>
         <div id="selected-symptoms"></div>
 
-        <h3>Enter Road Length:</h3>
-        <input type="number" id="road-length-input" placeholder="Enter road length in meters">
-
-        <h3>Select Defects:</h3>
         <div id="road-selector">
-            <svg
-                viewBox="40 74 130 60"
-                xmlns="http://www.w3.org/2000/svg">
+            <svg viewBox="40 74 130 60" xmlns="http://www.w3.org/2000/svg">
             <g id="pavement">
-                <rect
-                style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="pavement-rect"
-                width="121.56"
-                height="55.06"
-                x="44.47"
-                y="76.47" />
+                <rect style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="pavement-rect" width="121.56" height="55.06" x="44.47" y="76.47" />
             </g>
             <g id="markings">
-                <rect
-                style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="marking-1"
-                width="8.04"
-                height="3.76"
-                x="50.2"
-                y="101.3" />
-                <rect
-                style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="marking-2"
-                width="8.04"
-                height="3.76"
-                x="67.2"
-                y="101.3" />
-                <rect
-                style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="marking-3"
-                width="8.04"
-                height="3.76"
-                x="84.2"
-                y="101.3" />
-                <rect
-                style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="marking-4"
-                width="8.04"
-                height="3.76"
-                x="101.2"
-                y="101.3" />
-                <rect
-                style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="marking-5"
-                width="8.04"
-                height="3.76"
-                x="118.2"
-                y="101.3" />
-                <rect
-                style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="marking-6"
-                width="8.04"
-                height="3.76"
-                x="135.2"
-                y="101.3" />
-                <rect
-                style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="marking-7"
-                width="8.04"
-                height="3.76"
-                x="152.2"
-                y="101.3" />
+                <rect style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="marking-1" width="8.04" height="3.76" x="50.2" y="101.3" />
+                <rect style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="marking-2" width="8.04" height="3.76" x="67.2" y="101.3" />
+                <rect style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="marking-3" width="8.04" height="3.76" x="84.2" y="101.3" />
+                <rect style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="marking-4" width="8.04" height="3.76" x="101.2" y="101.3" />
+                <rect style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="marking-5" width="8.04" height="3.76" x="118.2" y="101.3" />
+                <rect style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="marking-6" width="8.04" height="3.76" x="135.2" y="101.3" />
+                <rect style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="marking-7" width="8.04" height="3.76" x="152.2" y="101.3" />
             </g>
             <g id="gully">
-                <rect
-                style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="gully-rect"
-                width="16.94"
-                height="8.9"
-                x="58"
-                y="79.2" />
-                <rect
-                style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="gully-hole-1"
-                width="2.4"
-                height="5.47"
-                x="60.28"
-                y="80.95" />
-                <rect
-                style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="gully-hole-2"
-                width="2.4"
-                height="5.47"
-                x="65.28"
-                y="80.95" />
-                <rect
-                style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-                id="gully-hole-3"
-                width="2.4"
-                height="5.47"
-                x="70.28"
-                y="80.95" />
+                <rect style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="gully-rect" width="16.94" height="8.9" x="58" y="79.2" />
+                <rect style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="gully-hole-1" width="2.4" height="5.47" x="60.28" y="80.95" />
+                <rect style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="gully-hole-2" width="2.4" height="5.47" x="65.28" y="80.95" />
+                <rect style="fill:#ffffff;fill-opacity:0;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" id="gully-hole-3" width="2.4" height="5.47" x="70.28" y="80.95" />
             </g>
             </svg>
-            <!-- <svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg">
-              <path id="pavement"       d="M10,150 h580 v40 h-580 z" fill="#ccc" stroke="#999"/>
-              <path id="markings"       d="M10,170 h580"         stroke="#fff" stroke-width="5"/>
-              <path id="gully"          d="M10,190 h580 v10 h-580 z" fill="#88c" stroke="#55a"/>
-            </svg> -->
         </div>
         <div id="symptom-buttons" class="symptom-buttons"></div>
-
-        <button id="diagnose-button">Continue</button>
 
         <div id="table-options">
             <input type="checkbox" id="full-tables" />
             <label for="full-tables">Show full tables</label>
         </div>
 
-        <div id="results"></div>
+        <div class="navigation">
+            <button id="back-to-step-1">Previous</button>
+            <button id="diagnose-button">Continue</button>
+        </div>
     </div>
+
+    <div id="step-3" class="step">
+        <h2>Results</h2>
+        <div id="results"></div>
+        <div class="navigation">
+            <button id="back-to-step-2">Previous</button>
+        </div>
+    </div>
+
+    </div> <!-- end symptom-checker -->
 
     <div id="footer"></div>
 
     <script src="../assets/js/scripts.js"></script>
     <script src="../assets/js/roadmd.js"></script>
+    <script src="../assets/js/wizard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand road length field width to 75%
- set background on the material toggle to remove the stray white strip
- center the Continue button on step 1
- balance the toggle button widths and fix highlight

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b61b5eaf0832e931c54fd0b94210f