### PR TITLE
Remove material check from defect filter

### DIFF
--- a/assets/js/dataLoader.js
+++ b/assets/js/dataLoader.js
@@ -160,20 +160,7 @@ async function loadAllData(basePath = '../assets/csv/') {
         if (d>-1 && c>-1) fullMatrix[d][c] = 1;
     });
 
-    const defectsByMaterial = {};
-    materials.forEach(mat => {
-        const set = new Set();
-        groups.forEach(g => {
-            severities.forEach(sev => {
-                fullTotalMatrix[mat][g][sev].forEach((arr, di) => {
-                    if (arr.some(v => v !== 0)) set.add(symptoms[di]);
-                });
-            });
-        });
-        defectsByMaterial[mat] = Array.from(set);
-    });
-
-    return { data:{ symptoms, causes, causeStrategyGroups, repairStrategies, repairStrategyGroups, timeSync: lifeMean }, fullMatrix, fullTotalMatrix, costMatrix, costMatrixNamed, costRank, lifeMean, lifeRange, defectsByMaterial };
+    return { data:{ symptoms, causes, causeStrategyGroups, repairStrategies, repairStrategyGroups, timeSync: lifeMean }, fullMatrix, fullTotalMatrix, costMatrix, costMatrixNamed, costRank, lifeMean, lifeRange };
 }
 
 if (typeof window !== 'undefined') {

--- a/assets/js/roadmd.js
+++ b/assets/js/roadmd.js
@@ -8,7 +8,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     const costRank = loaded.costRank;           // 1=low 2=medium 3=high
     const lifeMean = loaded.lifeMean;
     const lifeRange = loaded.lifeRange;
-    const defectsByMaterial = loaded.defectsByMaterial;
 
     // Map of road asset to the defects belonging to that asset. The
     // defect names must exactly match those loaded from the CSV files
@@ -217,12 +216,11 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     function filterSymptomButtons(allowedList) {
-        const material = getSelectedMaterial();
-        const valid = new Set(defectsByMaterial[material] || []);
         document.querySelectorAll(".symptom-button").forEach(btn => {
           const name = btn.textContent;
-          const show = allowedList.includes(name) && valid.has(name);
-          btn.style.display = show ? "inline-block" : "none";
+          btn.style.display = allowedList.includes(name)
+            ? "inline-block"
+            : "none";
         });
     }
 
@@ -256,11 +254,6 @@ document.addEventListener("DOMContentLoaded", async function () {
         });
     });
 
-    document.querySelectorAll('input[name="road-material"]').forEach(radio => {
-        radio.addEventListener('change', () => {
-            filterSymptomButtons(currentList);
-        });
-    });
 
     const step2Btn = document.getElementById('to-step-2');
     if (step2Btn) {


### PR DESCRIPTION
## Summary
- stop computing `defectsByMaterial`
- simplify symptom button filtering
- remove listener that checked material changes

## Testing
- `node --check assets/js/dataLoader.js`
- `node --check assets/js/roadmd.js`


------
https://chatgpt.com/codex/tasks/task_e_686d3a9f3d70832e8979ca8e8c0790f2