### PR TITLE
Align JS loader with MATLAB logic

### DIFF
--- a/assets/js/dataLoader.js
+++ b/assets/js/dataLoader.js
@@ -61,13 +61,37 @@ async function loadAllData(basePath = '../assets/csv/') {
     causeTreatment.forEach(r => { causeCategoryMap[r.Cause] = r['Cause category']; });
     const causeStrategyGroups = causes.map(c => causeCategoryMap[c] || '');
 
-    const repairStrategies = repairStrats.map(r => r.Name);
-    const repairStrategyGroups = repairStrats.map(r => r.Category);
-    const costMatrixNamed = repairStrats.map(r => r.Cost);
-    const lifeMean  = repairStrats.map(r => parseFloat(r.LifetimeMean) || 0);
-    const lifeMin   = repairStrats.map(r => parseFloat(r.LifetimeMinYears) || 0);
-    const lifeMax   = repairStrats.map(r => parseFloat(r.LifetimeMaxYears) || 0);
-    const lifeRange = lifeMax.map((max,i)=> Math.abs(max - lifeMin[i]));
+    const repairStrategies = [];
+    const repairStrategyGroups = [];
+    const costMatrixNamed = [];
+    const groupValues = [];
+    const roadTypes = [];
+    const lifeMean = [];
+    const lifeMin = [];
+    const lifeMax = [];
+    const lifeRange = [];
+    const repairById = {};
+    const repairNameToIndex = {};
+
+    repairStrats.forEach(r => {
+        repairById[r.id] = r;
+        if (repairNameToIndex[r.Name] === undefined) {
+            const idx = repairStrategies.length;
+            repairNameToIndex[r.Name] = idx;
+            repairStrategies.push(r.Name);
+            repairStrategyGroups.push(r.Category);
+            costMatrixNamed.push(r.Cost);
+            groupValues.push(r['When (# defects)'] || '');
+            roadTypes.push(r['Where? (road type)'] || '');
+            const mn = parseFloat(r.LifetimeMean);
+            const mnMin = parseFloat(r.LifetimeMinYears);
+            const mnMax = parseFloat(r.LifetimeMaxYears);
+            lifeMean.push(isNaN(mn) ? -100 : mn);
+            lifeMin.push(isNaN(mnMin) ? -100 : mnMin);
+            lifeMax.push(isNaN(mnMax) ? -100 : mnMax);
+            lifeRange.push((!isNaN(mnMin) && !isNaN(mnMax)) ? (mnMax - mnMin) : -100);
+        }
+    });
 
     function costWeight(c) {
         const lc = (c || '').toLowerCase();
@@ -77,79 +101,93 @@ async function loadAllData(basePath = '../assets/csv/') {
         if (lc.includes('high')) return 0.1;
         return 0;
     }
-
-    const costMatrix = costMatrixNamed.map(costWeight);
-    const costRank = costMatrixNamed.map(c => {
+    function costRankVal(c) {
         const lc = (c || '').toLowerCase();
         if (lc.includes('low')) return 1;
+        if (lc.includes('medium/high')) return 3;
         if (lc.includes('medium')) return 2;
         if (lc.includes('high')) return 3;
         return 0;
-    });
+    }
+
+    const costMatrix = costMatrixNamed.map(costWeight);
+    const costRank = costMatrixNamed.map(costRankVal);
 
     const severityIndex = { 'Very Low':0,'Low':1,'Medium':2,'High':3,'Unknown':4 };
     const severities = Object.keys(severityIndex);
     const materials = ['asphalt','concrete'];
     const groups = ['Individual','Group'];
+
     const nSymptoms = symptoms.length;
     const nRepairs = repairStrategies.length;
 
-    // initialise 5D matrix: material -> group -> severity -> defect -> repair
+    const repairMaterialMask = Array.from({length:nRepairs},()=>[0,0]);
+    const repairGroupMask = Array.from({length:nRepairs},()=>[
+        Array(5).fill(0),
+        Array(5).fill(0)
+    ]);
+
+    repairStrategies.forEach((name, idx) => {
+        const road = (roadTypes[idx] || '').toLowerCase();
+        if (/concrete/.test(road) || /both/.test(road)) repairMaterialMask[idx][1] = 1;
+        if (/asphalt/.test(road) || /both/.test(road)) repairMaterialMask[idx][0] = 1;
+
+        const gv = (groupValues[idx] || '').toLowerCase();
+        if (gv.includes('both')) {
+            repairGroupMask[idx][0].fill(1,0,4);
+            repairGroupMask[idx][1].fill(1,0,4);
+        }
+        if (gv.includes('individual')) {
+            repairGroupMask[idx][0].fill(1,0,4);
+        }
+        if (gv.includes('widespread')) {
+            if (gv.includes('very low')) repairGroupMask[idx][1][0] = 1;
+            else if (gv.includes('low')) repairGroupMask[idx][1][1] = 1;
+            else if (gv.includes('medium')) repairGroupMask[idx][1][2] = 1;
+            else if (gv.includes('high') || gv.includes('severe')) repairGroupMask[idx][1][3] = 1;
+            else repairGroupMask[idx][1].fill(1,0,4);
+        }
+    });
+
+    repairGroupMask.forEach(mask => {
+        for (let g=0; g<2; g++) {
+            mask[g][4] = 0.05*mask[g][0] + 0.10*mask[g][1] + 0.30*mask[g][2] + 0.55*mask[g][3];
+        }
+    });
+
+    const repairDefectMask = Array.from({length:5},()=>Array.from({length:nSymptoms},()=>Array(nRepairs).fill(0)));
+    defectRepair.forEach(row => {
+        const d = symptoms.indexOf(row.Defect);
+        const sIdx = parseInt(row.Severity,10)+1;
+        const rInfo = repairById[row.RepairStrat];
+        if (d===-1 || !rInfo) return;
+        const ridx = repairNameToIndex[rInfo.Name];
+        if (ridx===undefined) return;
+        if (repairDefectMask[sIdx-1]) repairDefectMask[sIdx-1][d][ridx] = 1;
+    });
+
+    for (let d=0; d<nSymptoms; d++) {
+        for (let r=0; r<nRepairs; r++) {
+            repairDefectMask[4][d][r] = (repairDefectMask[0][d][r]||repairDefectMask[1][d][r]||repairDefectMask[2][d][r]||repairDefectMask[3][d][r]) ? 1 : 0;
+        }
+    }
+
     const fullTotalMatrix = {};
-    materials.forEach(mat => {
+    materials.forEach((mat, mi) => {
         fullTotalMatrix[mat] = {};
-        groups.forEach(g => {
+        groups.forEach((g, gi) => {
             fullTotalMatrix[mat][g] = {};
-            severities.forEach(sev => {
-                fullTotalMatrix[mat][g][sev] = Array.from({length:nSymptoms},()=>Array(nRepairs).fill(0));
-            });
-        });
-    });
-
-    const repairById = {};
-    repairStrats.forEach(r => { repairById[r.id] = r; });
-
-    defectRepair.forEach(r => {
-        const d = symptoms.indexOf(r.Defect);
-        const sName = r.SeverityName || 'Unknown';
-        const rInfo = repairById[r.RepairStrat];
-        if (d === -1 || !rInfo) return;
-        const ridx = repairStrategies.indexOf(rInfo.Name);
-        if (ridx === -1) return;
-
-        const mats = /both/i.test(rInfo['Where? (road type)']) ? materials
-                     : /concrete/i.test(rInfo['Where? (road type)']) ? ['concrete']
-                     : /asphalt/i.test(rInfo['Where? (road type)']) ? ['asphalt']
-                     : materials;
-
-        const groupTxt = rInfo['When (# defects)'] || '';
-        const grps = [];
-        if (/individual/i.test(groupTxt)) grps.push('Individual');
-        if (/widespread/i.test(groupTxt)) grps.push('Group');
-        if (/both/i.test(groupTxt) || grps.length===0) { grps.push('Individual'); grps.push('Group'); }
-
-        mats.forEach(mat => {
-            grps.forEach(g => {
-                if (fullTotalMatrix[mat][g][sName]) {
-                    fullTotalMatrix[mat][g][sName][d][ridx] = costWeight(rInfo.Cost) * (parseFloat(rInfo.LifetimeMean) || 1);
+            severities.forEach((sev, si) => {
+                const matArr = Array.from({length:nSymptoms},()=>Array(nRepairs).fill(0));
+                for (let d=0; d<nSymptoms; d++) {
+                    for (let r=0; r<nRepairs; r++) {
+                        if (repairMaterialMask[r][mi] && repairGroupMask[r][gi][si] && repairDefectMask[si][d][r]) {
+                            matArr[d][r] = 1;
+                        }
+                    }
                 }
+                fullTotalMatrix[mat][g][sev] = matArr;
             });
-        });
-    });
-
-    // derive Unknown severity by weighted sum
-    materials.forEach(mat => {
-        groups.forEach(g => {
-            const u = fullTotalMatrix[mat][g]['Unknown'];
-            if (!u) return;
-            for (let d=0; d<nSymptoms; d++) {
-                for (let r=0; r<nRepairs; r++) {
-                    u[d][r] = 0.05*fullTotalMatrix[mat][g]['Very Low'][d][r]
-                            + 0.10*fullTotalMatrix[mat][g]['Low'][d][r]
-                            + 0.30*fullTotalMatrix[mat][g]['Medium'][d][r]
-                            + 0.55*fullTotalMatrix[mat][g]['High'][d][r];
-                }
-            }
         });
     });
 
@@ -160,7 +198,16 @@ async function loadAllData(basePath = '../assets/csv/') {
         if (d>-1 && c>-1) fullMatrix[d][c] = 1;
     });
 
-    return { data:{ symptoms, causes, causeStrategyGroups, repairStrategies, repairStrategyGroups, timeSync: lifeMean }, fullMatrix, fullTotalMatrix, costMatrix, costMatrixNamed, costRank, lifeMean, lifeRange };
+    return {
+        data:{ symptoms, causes, causeStrategyGroups, repairStrategies, repairStrategyGroups, timeSync: lifeMean },
+        fullMatrix,
+        fullTotalMatrix,
+        costMatrix,
+        costMatrixNamed,
+        costRank,
+        lifeMean,
+        lifeRange
+    };
 }
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- overhaul dataLoader.js to mirror the MATLAB loader logic
- maintain separate masks for material, group and severity
- calculate cost ranking consistent with MATLAB
- build final 5‑D repair matrix using binary weights

## Testing
- `node -e "require('./assets/js/dataLoader.js'); console.log('ok');"`
- `node - <<'NODE'
const {loadAllData}=require('./assets/js/dataLoader.js');
loadAllData('assets/csv/').then(res=>{
 console.log('materials', Object.keys(res.fullTotalMatrix));
 console.log('example', res.fullTotalMatrix.asphalt.Individual['Low'][0].slice(0,5));
}).catch(err=>{console.error(err);});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_686d44736398832e94061aba4b704a06