### PR TITLE
Modify warning modal heading style

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -69,6 +69,10 @@ footer {
     border-radius: 5px;
     text-align: center;
 }
+.warning-modal h3 {
+    margin-top: 0;
+    margin-bottom: 10px;
+}
 .warning-modal button {
     margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- adjust `.warning-modal` heading spacing to remove extra top margin

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687044eae234832e959d9580d71639dc