### PR TITLE
Use event delegation for warning modal

### DIFF
--- a/assets/js/warning.js
+++ b/assets/js/warning.js
@@ -8,16 +8,10 @@ function showWarning(msg) {
   modal.style.display = 'flex';
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('click', function (e) {
   const modal = document.getElementById('warning-modal');
   if (!modal) return;
-  const closeBtn = document.getElementById('warning-close');
-  closeBtn.addEventListener('click', function () {
+  if (e.target.id === 'warning-close' || e.target === modal) {
     modal.style.display = 'none';
-  });
-  modal.addEventListener('click', function (e) {
-    if (e.target === modal) {
-      modal.style.display = 'none';
-    }
-  });
+  }
 });


### PR DESCRIPTION
## Summary
- simplify modal close handling by delegating click events at the document level

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68704a737954832ea63e4924b5f10180