### PR TITLE
Ensure diagnosis runs before showing Step 3 in wizard navigation

### DIFF
--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function () {
     const steps = document.querySelectorAll('.step');
     const navItems = document.querySelectorAll('.nav-item');
+    const diagnoseButton = document.getElementById('diagnose-button');
     let currentStep = 1;
 
     function showStep(n) {
@@ -13,30 +14,42 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    document.getElementById('to-step-2').addEventListener('click', () => showStep(2));
-    document.getElementById('back-to-step-1').addEventListener('click', () => showStep(1));
+    function shouldTriggerDiagnosis(targetStep) {
+        return targetStep === 3 && currentStep !== 3;
+    }
+
+    function goToStep(targetStep) {
+        if (shouldTriggerDiagnosis(targetStep) && diagnoseButton) {
+            diagnoseButton.click();
+            return;
+        }
+        showStep(targetStep);
+    }
+
+    document.getElementById('to-step-2').addEventListener('click', () => goToStep(2));
+    document.getElementById('back-to-step-1').addEventListener('click', () => goToStep(1));
     document.getElementById('diagnose-button').addEventListener('click', () => showStep(3));
-    document.getElementById('back-to-step-2').addEventListener('click', () => showStep(2));
+    document.getElementById('back-to-step-2').addEventListener('click', () => goToStep(2));
 
     navItems.forEach((item, idx) => {
         const targetStep = idx + 1;
         item.setAttribute('role', 'button');
         item.setAttribute('tabindex', '0');
-        item.addEventListener('click', () => showStep(targetStep));
+        item.addEventListener('click', () => goToStep(targetStep));
         item.addEventListener('keydown', (event) => {
             if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault();
-                showStep(targetStep);
+                goToStep(targetStep);
             }
             if (event.key === 'ArrowRight' && currentStep < steps.length) {
                 event.preventDefault();
                 event.stopPropagation();
-                showStep(currentStep + 1);
+                goToStep(currentStep + 1);
             }
             if (event.key === 'ArrowLeft' && currentStep > 1) {
                 event.preventDefault();
                 event.stopPropagation();
-                showStep(currentStep - 1);
+                goToStep(currentStep - 1);
             }
         });
     });

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -28,7 +28,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     document.getElementById('to-step-2').addEventListener('click', () => goToStep(2));
     document.getElementById('back-to-step-1').addEventListener('click', () => goToStep(1));
-    document.getElementById('diagnose-button').addEventListener('click', () => showStep(3));
+    if (diagnoseButton) {
+        diagnoseButton.addEventListener('click', () => showStep(3));
+    }
     document.getElementById('back-to-step-2').addEventListener('click', () => goToStep(2));
 
     navItems.forEach((item, idx) => {


### PR DESCRIPTION
### Motivation
- Prevent top-nav or keyboard navigation to Step 3 from bypassing the diagnosis pipeline so users cannot see empty or stale results.
- Ensure the Results page is only shown after the existing `#diagnose-button` action runs to keep the step flow consistent.

### Description
- Added a `diagnoseButton` reference, a `shouldTriggerDiagnosis()` predicate and a `goToStep()` helper, and replaced direct `showStep(...)` calls in button handlers, top-nav clicks and keyboard navigation with `goToStep(...)`.
- `goToStep()` triggers `diagnoseButton.click()` when transitioning to Step 3 from another step, while preserving the existing `#diagnose-button` handler which still advances to Step 3 after diagnosis completes.

### Testing
- Ran `node --check assets/js/wizard.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd9990413c832eb8a0303309a21ab9)