### PR TITLE
Remove "Very Low" severity and update RoadGP weights to Low/Medium/High model

### DIFF
--- a/assets/js/dataLoader.js
+++ b/assets/js/dataLoader.js
@@ -197,9 +197,10 @@ async function loadAllData(basePath = '../assets/csv/') {
         }
     });
 
+    const blend = [0.10, 0.30, 0.60];
     repairGroupMask.forEach(mask => {
         for (let g=0; g<2; g++) {
-            mask[g][3] = 0.10*mask[g][0] + 0.30*mask[g][1] + 0.60*mask[g][2];
+            mask[g][3] = blend[0]*mask[g][0] + blend[1]*mask[g][1] + blend[2]*mask[g][2];
         }
     });
 
@@ -284,7 +285,6 @@ async function loadAllData(basePath = '../assets/csv/') {
     }
 
     // Blend the Unknown (index 3) severity as weighted combination of 0..2
-    const blend = [0.10, 0.30, 0.60];
     for (let m = 0; m < 2; m++) {
     for (let g = 0; g < 2; g++) {
         for (let d = 0; d < nSymptoms; d++) {

--- a/assets/js/dataLoader.js
+++ b/assets/js/dataLoader.js
@@ -163,7 +163,7 @@ async function loadAllData(basePath = '../assets/csv/') {
     const costMatrix = costMatrixNamed.map(costWeight);
     const costRank = costMatrixNamed.map(costRankVal);
 
-    const severityIndex = { 'Very Low':0,'Low':1,'Medium':2,'High':3,'Unknown':4 };
+    const severityIndex = { 'Low':0,'Medium':1,'High':2,'Unknown':3 };
     const severities = Object.keys(severityIndex);
     const materials = ['asphalt','concrete'];
     const groups = ['Individual','Widespread'];
@@ -172,8 +172,8 @@ async function loadAllData(basePath = '../assets/csv/') {
 
     const repairMaterialMask = Array.from({length:nRepairs},()=>[0,0]);
     const repairGroupMask = Array.from({length:nRepairs},()=>[
-        Array(5).fill(0),
-        Array(5).fill(0)
+        Array(4).fill(0),
+        Array(4).fill(0)
     ]);
 
     repairStrategies.forEach((name, idx) => {
@@ -183,33 +183,33 @@ async function loadAllData(basePath = '../assets/csv/') {
 
         const gv = (groupValues[idx] || '').toLowerCase();
         if (gv.includes('both')) {
-            repairGroupMask[idx][0].fill(1,0,4);
-            repairGroupMask[idx][1].fill(1,0,4);
+            repairGroupMask[idx][0].fill(1,0,3);
+            repairGroupMask[idx][1].fill(1,0,3);
         }
         if (gv.includes('individual')) {
-            repairGroupMask[idx][0].fill(1,0,4);
+            repairGroupMask[idx][0].fill(1,0,3);
         }
         if (gv.includes('widespread')) {
-            if (gv.includes('very low')) repairGroupMask[idx][1][0] = 1;
-            else if (gv.includes('low')) repairGroupMask[idx][1][1] = 1;
-            else if (gv.includes('medium')) repairGroupMask[idx][1][2] = 1;
-            else if (gv.includes('high') || gv.includes('severe')) repairGroupMask[idx][1][3] = 1;
-            else repairGroupMask[idx][1].fill(1,0,4);
+            if (gv.includes('low')) repairGroupMask[idx][1][0] = 1;
+            else if (gv.includes('medium')) repairGroupMask[idx][1][1] = 1;
+            else if (gv.includes('high') || gv.includes('severe')) repairGroupMask[idx][1][2] = 1;
+            else repairGroupMask[idx][1].fill(1,0,3);
         }
     });
 
     repairGroupMask.forEach(mask => {
         for (let g=0; g<2; g++) {
-            mask[g][4] = 0.05*mask[g][0] + 0.10*mask[g][1] + 0.30*mask[g][2] + 0.55*mask[g][3];
+            mask[g][3] = 0.10*mask[g][0] + 0.30*mask[g][1] + 0.60*mask[g][2];
         }
     });
 
-    const repairDefectMask = Array.from({length:5},()=>Array.from({length:nSymptoms},()=>Array(nRepairs).fill(0)));
+    const repairDefectMask = Array.from({length:4},()=>Array.from({length:nSymptoms},()=>Array(nRepairs).fill(0)));
     defectRepair.forEach(row => {
         const d = symptoms.indexOf(row.Defect);
-        const sIdx = Number(row.Severity); // 0..3 in CSV (Very Low..High)
+        const rawSeverity = Number(row.Severity);
+        const sIdx = (rawSeverity >= 1 && rawSeverity <= 3) ? rawSeverity - 1 : rawSeverity; // Low..High -> 0..2
         const rInfo = repairById[row.RepairStrat];
-        if (d === -1 || !rInfo || Number.isNaN(sIdx) || sIdx < 0 || sIdx > 3) return;
+        if (d === -1 || !rInfo || Number.isNaN(sIdx) || sIdx < 0 || sIdx > 2) return;
 
         const ridx = repairNameToIndex[rInfo.Name];
         if (ridx === undefined) return;
@@ -219,7 +219,7 @@ async function loadAllData(basePath = '../assets/csv/') {
 
     for (let d=0; d<nSymptoms; d++) {
         for (let r=0; r<nRepairs; r++) {
-            repairDefectMask[4][d][r] = (repairDefectMask[0][d][r]||repairDefectMask[1][d][r]||repairDefectMask[2][d][r]||repairDefectMask[3][d][r]) ? 1 : 0;
+            repairDefectMask[3][d][r] = (repairDefectMask[0][d][r]||repairDefectMask[1][d][r]||repairDefectMask[2][d][r]) ? 1 : 0;
         }
     }
 
@@ -245,12 +245,12 @@ async function loadAllData(basePath = '../assets/csv/') {
     });
 
     // Build 5D DefectAmount, CostDefectAmount, CostLifeDefectAmount
-    // Dimensions: [material:2][group:2][severity:5][symptom:nSymptoms][repair:nRepairs]
+    // Dimensions: [material:2][group:2][severity:4][symptom:nSymptoms][repair:nRepairs]
 
     function make5D(fillVal=0) {
     return Array.from({length:2}, () => // material
         Array.from({length:2}, () =>     // group (Individual/Widespread)
-        Array.from({length:5}, () =>   // severity (Very Low..High, Unknown)
+        Array.from({length:4}, () =>   // severity (Low..High, Unknown)
             Array.from({length:nSymptoms}, () => Array(nRepairs).fill(fillVal))
         )
         )
@@ -264,7 +264,7 @@ async function loadAllData(basePath = '../assets/csv/') {
 
     for (let r = 0; r < nRepairs; r++) {
     for (let g = 0; g < 2; g++) {
-        for (let s = 0; s < 5; s++) {
+        for (let s = 0; s < 3; s++) {
         const present = repairGroupMask[r][g][s] ? 1 : 0; // 0/1
         if (!present) continue;
 
@@ -283,21 +283,21 @@ async function loadAllData(basePath = '../assets/csv/') {
     }
     }
 
-    // Blend the Unknown (index 4) severity as weighted combination of 0..3
-    const blend = [0.05, 0.10, 0.30, 0.55];
+    // Blend the Unknown (index 3) severity as weighted combination of 0..2
+    const blend = [0.10, 0.30, 0.60];
     for (let m = 0; m < 2; m++) {
     for (let g = 0; g < 2; g++) {
         for (let d = 0; d < nSymptoms; d++) {
         for (let r = 0; r < nRepairs; r++) {
             let v = 0, vc = 0, vcl = 0;
-            for (let s = 0; s < 4; s++) {
+            for (let s = 0; s < 3; s++) {
             v   += blend[s] * DefectAmount[m][g][s][d][r];
             vc  += blend[s] * CostDefectAmount[m][g][s][d][r];
             vcl += blend[s] * CostLifeDefectAmount[m][g][s][d][r];
             }
-            DefectAmount[m][g][4][d][r]        = v;
-            CostDefectAmount[m][g][4][d][r]    = vc;
-            CostLifeDefectAmount[m][g][4][d][r]= vcl;
+            DefectAmount[m][g][3][d][r]        = v;
+            CostDefectAmount[m][g][3][d][r]    = vc;
+            CostLifeDefectAmount[m][g][3][d][r]= vcl;
         }
         }
     }
@@ -309,7 +309,7 @@ async function loadAllData(basePath = '../assets/csv/') {
     for (let m = 0; m < 2; m++) {
         if (!repairMaterialMask[r][m]) continue;
         for (let g = 0; g < 2; g++) {
-        for (let s = 0; s < 5; s++) {
+        for (let s = 0; s < 4; s++) {
             for (let d = 0; d < nSymptoms; d++) {
             MaterialCheck[m][g][s][d][r] = 1;
             }
@@ -320,7 +320,7 @@ async function loadAllData(basePath = '../assets/csv/') {
 
     // RepairMatrix: expand your repairDefectMask into 5D (no material/group gating here)
     const RepairMatrix = make5D(0);
-    for (let s = 0; s < 5; s++) {
+    for (let s = 0; s < 4; s++) {
     for (let d = 0; d < nSymptoms; d++) {
         for (let r = 0; r < nRepairs; r++) {
         if (!repairDefectMask[s][d][r]) continue;
@@ -338,7 +338,7 @@ async function loadAllData(basePath = '../assets/csv/') {
     const out = make5D(0);
     for (let m = 0; m < 2; m++)
         for (let g = 0; g < 2; g++)
-        for (let s = 0; s < 5; s++)
+        for (let s = 0; s < 4; s++)
             for (let d = 0; d < nSymptoms; d++)
             for (let r = 0; r < nRepairs; r++)
                 out[m][g][s][d][r] = A[m][g][s][d][r] * B[m][g][s][d][r];

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -102,8 +102,8 @@ document.addEventListener("DOMContentLoaded", async function () {
         chip.className = "symptom-chip";
         chip.textContent = symptom;
 
-        // Vertical grid of 5 severities
-        const severities = ["Very Low","Low","Medium","High","Unknown"];
+        // Vertical grid of 4 severities
+        const severities = ["Low","Medium","High","Unknown"];
         const grid = document.createElement("div");
         grid.className = "severity-grid";
 
@@ -199,7 +199,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         // map names → indices
         const mi = ['asphalt','concrete'].indexOf((material || '').toLowerCase());
         const gi = ['Individual','Widespread'].indexOf(groupName);
-        const si = ['Very Low','Low','Medium','High','Unknown'].indexOf(severity);
+        const si = ['Low','Medium','High','Unknown'].indexOf(severity);
 
         if (mi < 0 || gi < 0 || si < 0 || symptomIndex < 0) {
             return Array(nRepairs).fill(0);


### PR DESCRIPTION
### Motivation
- The data model and CSV have deprecated the `Very Low` severity, so the frontend must stop exposing it and align with the new CSV encoding. 
- Unknown-severity blending and internal weighting must be updated from the old four-part blend (`0.05/0.10/0.30/0.55`) to the new three-part blend (`0.10/0.30/0.60`).
- Repair-group and mask logic must be simplified to the `Low`/`Medium`/`High` slices so derived matrices remain consistent with the CSV.

### Description
- Updated the symptom entry UI in `assets/js/roadgp.js` to present `Low`, `Medium`, `High`, and `Unknown` instead of including `Very Low`, and adjusted the severity lookup to match `['Low','Medium','High','Unknown']`.
- Refactored `assets/js/dataLoader.js` to change `severityIndex` to `{'Low':0,'Medium':1,'High':2,'Unknown':3}` and reduced severity-related dimensions from 5 to 4 across masks and matrices.
- Reworked parsing and gating logic in `dataLoader.js` to remove `very low` handling from `repairGroupMask` and to adjust fill ranges and loop bounds accordingly.
- Added CSV compatibility mapping by converting CSV severity values encoded as `1..3` into internal indices `0..2` (`Low..High`) and replaced the unknown blending vector with `const blend = [0.10, 0.30, 0.60]` so the Unknown index is computed correctly.

### Testing
- Ran an automated search with `rg -n` for `Very Low`, `very low`, `0.05`, and `0.55` across the updated JS files to confirm references to the old severity or weights are removed.
- Verified the diff for the changes was limited to `assets/js/dataLoader.js` and `assets/js/roadgp.js` using an automated `git diff` inspection of those files.
- Programmatically inspected relevant code regions with file listings/line prints (e.g. `nl -ba`) to confirm arrays, loop bounds, and the new `blend` vector are present and consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3965cf2b4832e990ce4a5770226a4)