### PR TITLE
Classify defects by keyword, add step-2 guidance, and toggle SVG region filters

### DIFF
--- a/assets/css/roadgp.css
+++ b/assets/css/roadgp.css
@@ -549,3 +549,13 @@ input.severity-quantity::-webkit-outer-spin-button {
         margin-top: 0;
     }
 }
+
+.step2-guidance {
+    background: #eef6ff;
+    border: 1px solid #cfe4ff;
+    border-left: 4px solid #007BFF;
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-bottom: 12px;
+    font-size: 0.95rem;
+}

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -72,19 +72,24 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     const regionToSymptoms = buildRegionToSymptoms(data.symptoms);
-    const potentialMisclassifications = data.symptoms.filter(symptom => {
-        const normalized = symptom.toLowerCase();
-        const matches = Object.entries(regionClassifierRules)
-            .filter(([, keywords]) => keywords.some(keyword => normalized.includes(keyword)))
-            .map(([region]) => region);
-        return matches.length > 1;
-    });
+    const potentialMisclassifications = data.symptoms
+        .map(symptom => {
+            const normalized = symptom.toLowerCase();
+            const matchedRegions = Object.entries(regionClassifierRules)
+                .filter(([, keywords]) => keywords.some(keyword => normalized.includes(keyword)))
+                .map(([region]) => region);
+
+            return matchedRegions.length > 1
+                ? { symptom, matchedRegions }
+                : null;
+        })
+        .filter(Boolean);
 
     if (regionToSymptoms.unclassified.length) {
         console.warn("Unclassified defects (step 2 filter):", regionToSymptoms.unclassified);
     }
     if (potentialMisclassifications.length) {
-        console.warn("Potentially misclassified defects (ambiguous keyword score):", potentialMisclassifications);
+        console.warn("Defects matching keywords from multiple regions:", potentialMisclassifications);
     }
 
     const symptomButtons = document.getElementById("symptom-buttons");

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -9,41 +9,83 @@ document.addEventListener("DOMContentLoaded", async function () {
     const lifeMean = loaded.lifeMean;
     const lifeRange = loaded.lifeRange;
 
-    // Map of road asset to the defects belonging to that asset. The
-    // defect names must exactly match those loaded from the CSV files
-    // otherwise the filter will fail to show/hide them correctly.
-    const regionToSymptoms = {
+    // Classify defect names into road assets using resilient keyword rules.
+    // This avoids brittle exact-string matching when CSV names are made
+    // more user-friendly (e.g. "Transverse" -> "Transverse cracking").
+    const regionClassifierRules = {
         pavement: [
-            "Transverse",
-            "Longitudinal",
-            "Edge",
-            "Block",
-            "Alligator",
-            "Potholes",
-            "Patches",
-            "Shoving",
-            "Rutting",
-            "Distortion",
-            "Raveling",
-            "Bleeding",
-            "Spalling",
-            "Surface irregularities",
-            "Slab rocking",
-            "Stepping"
+            "transverse", "longitudinal", "edge", "block", "alligator",
+            "pothole", "patch", "shoving", "rutting", "distortion",
+            "ravel", "bleeding", "spalling", "surface irregular", "slab",
+            "stepping", "cracking", "scaling", "crazing", "pop-out", "joint", "depression", "heave", "punchout", "compression"
         ],
         markings: [
-            "Material fault",
-            "Skidding",
-            "Poor retroreflectivity",
-            "Poor luminance",
-            "Stud defects",
-            "Stud retroreflectivity"
+            "marking", "retroreflect", "luminance", "stud", "skidding", "material fault"
         ],
         gully: [
-            "Blockage (gully)",
-            "Flooding and standing water"
+            "gully", "flood", "standing water", "drainage", "drain", "blockage"
         ]
     };
+
+    function classifySymptom(symptom) {
+        if (!symptom) return null;
+
+        const normalized = symptom.toLowerCase();
+        const scores = Object.fromEntries(
+            Object.keys(regionClassifierRules).map(region => [region, 0])
+        );
+
+        for (const [region, keywords] of Object.entries(regionClassifierRules)) {
+            keywords.forEach(keyword => {
+                if (normalized.includes(keyword)) {
+                    // Favor more specific keyword hits over broad ones.
+                    scores[region] += keyword.length;
+                }
+            });
+        }
+
+        const ranked = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+        const [topRegion, topScore] = ranked[0];
+        const secondScore = ranked[1] ? ranked[1][1] : 0;
+
+        if (topScore === 0) return null;
+        if (topScore === secondScore) return null; // ambiguous
+        return topRegion;
+    }
+
+    function buildRegionToSymptoms(symptoms) {
+        const mapping = { pavement: [], markings: [], gully: [] };
+        const unclassified = [];
+
+        symptoms.forEach(symptom => {
+            const region = classifySymptom(symptom);
+            if (region && mapping[region]) {
+                mapping[region].push(symptom);
+            } else {
+                unclassified.push(symptom);
+            }
+        });
+
+        // Keep all defects accessible even if unclassified.
+        mapping.unclassified = unclassified;
+        return mapping;
+    }
+
+    const regionToSymptoms = buildRegionToSymptoms(data.symptoms);
+    const potentialMisclassifications = data.symptoms.filter(symptom => {
+        const normalized = symptom.toLowerCase();
+        const matches = Object.entries(regionClassifierRules)
+            .filter(([, keywords]) => keywords.some(keyword => normalized.includes(keyword)))
+            .map(([region]) => region);
+        return matches.length > 1;
+    });
+
+    if (regionToSymptoms.unclassified.length) {
+        console.warn("Unclassified defects (step 2 filter):", regionToSymptoms.unclassified);
+    }
+    if (potentialMisclassifications.length) {
+        console.warn("Potentially misclassified defects (ambiguous keyword score):", potentialMisclassifications);
+    }
 
     const symptomButtons = document.getElementById("symptom-buttons");
     const selectedSymptoms = document.getElementById("selected-symptoms");
@@ -149,25 +191,36 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     // ————— Hook up the SVG click-zones —————
     let currentRegion = null;
-    let currentList = [];
+    let currentList = data.symptoms;
     document
     .querySelectorAll("#road-selector svg g[id]")
     .forEach(regionEl => {
         regionEl.style.cursor = "pointer";
         regionEl.addEventListener("click", () => {
-        const region   = regionEl.id;    // "markings", "gullies", etc.
-        const list     = regionToSymptoms[region] || [];
-        currentRegion  = region;
-        currentList    = list;
+        const region = regionEl.id;    // "markings", "gully", "pavement"
 
-        // Optionally highlight the clicked region
+        // Clicking the active asset again clears the filter.
+        const isTogglingOff = currentRegion === region;
+        if (isTogglingOff) {
+            currentRegion = null;
+            currentList = data.symptoms;
+            document
+                .querySelectorAll("#road-selector svg g[id]")
+                .forEach(el => el.classList.remove("active"));
+            filterSymptomButtons(currentList);
+            return;
+        }
+
+        const list = regionToSymptoms[region] || [];
+        currentRegion = region;
+        currentList = list.length ? list : data.symptoms;
+
         document
             .querySelectorAll("#road-selector svg g[id]")
             .forEach(el => el.classList.remove("active"));
         regionEl.classList.add("active");
 
-        // Filter your button grid (if you still have that)
-        filterSymptomButtons(list);
+        filterSymptomButtons(currentList);
         });
     });
 

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -192,9 +192,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     // ————— Hook up the SVG click-zones —————
     let currentRegion = null;
     let currentList = data.symptoms;
-    document
-    .querySelectorAll("#road-selector svg g[id]")
-    .forEach(regionEl => {
+    const svgRegions = document.querySelectorAll("#road-selector svg g[id]");
+
+    function clearActiveRegion() {
+        svgRegions.forEach(el => el.classList.remove("active"));
+    }
+
+    svgRegions.forEach(regionEl => {
         regionEl.style.cursor = "pointer";
         regionEl.addEventListener("click", () => {
         const region = regionEl.id;    // "markings", "gully", "pavement"
@@ -204,9 +208,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         if (isTogglingOff) {
             currentRegion = null;
             currentList = data.symptoms;
-            document
-                .querySelectorAll("#road-selector svg g[id]")
-                .forEach(el => el.classList.remove("active"));
+            clearActiveRegion();
             filterSymptomButtons(currentList);
             return;
         }
@@ -215,9 +217,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         currentRegion = region;
         currentList = list.length ? list : data.symptoms;
 
-        document
-            .querySelectorAll("#road-selector svg g[id]")
-            .forEach(el => el.classList.remove("active"));
+        clearActiveRegion();
         regionEl.classList.add("active");
 
         filterSymptomButtons(currentList);

--- a/pages/roadgp.html
+++ b/pages/roadgp.html
@@ -63,6 +63,9 @@
 
     <div id="step-2" class="step">
         <h2>Select Defects</h2>
+        <div class="step2-guidance" role="note" aria-label="How to use step 2">
+            <strong>New here?</strong> 1) Click a road part in the diagram to narrow defects by asset. 2) Click the same part again to clear the filter. 3) Add defects and enter quantity by severity. 4) You can also search defects directly.
+        </div>
         <input type="text" id="symptom-input" aria-label="Search for road defects" placeholder="Search for road defects...">
         <div id="autocomplete-list" class="autocomplete-list"></div>
         <div id="selected-symptoms"></div>


### PR DESCRIPTION
### Motivation
- Improve robustness of defect-to-asset mapping by using keyword-based classification instead of brittle exact-string matching. 
- Make step 2 more discoverable by adding an in-UI guidance panel. 
- Let users toggle asset filters on/off by clicking the SVG region to simplify defect browsing.

### Description
- Replace the static `regionToSymptoms` exact-match map with a keyword-driven `regionClassifierRules` and implement `classifySymptom` and `buildRegionToSymptoms` to build `regionToSymptoms` from `data.symptoms`.
- Expand keyword lists for `pavement`, `markings`, and `gully` to cover more common defect name variants and add console warnings for `unclassified` and potentially ambiguous defects.
- Initialize `currentList` to `data.symptoms` and update the SVG region click handler to toggle filters off when clicking the active region and to fall back to the full symptom list when a region has no mapped items.
- Add a visual guidance box in `pages/roadgp.html` (`.step2-guidance`) and corresponding styles in `assets/css/roadgp.css` to explain how to use step 2.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39b0f2928832eb6d267509cf2e52d)