### PR TITLE
Fix repair percentages by reading current RepairStrats CSV fields

### DIFF
--- a/assets/js/dataLoader.js
+++ b/assets/js/dataLoader.js
@@ -131,8 +131,8 @@ async function loadAllData(basePath = '../assets/csv/') {
             repairStrategies.push(r.Name);
             repairStrategyGroups.push(r.Category);
             costMatrixNamed.push(r.Cost);
-            groupValues.push(r['When (# defects)'] || '');
-            roadTypes.push(r['Where? (road type)'] || '');
+            groupValues.push(r['When (# defects)'] || r.Situation || '');
+            roadTypes.push(r['Where? (road type)'] || r.RoadType || '');
             const mn = parseFloat(r.LifetimeMean);
             const mnMin = parseFloat(r.LifetimeMinYears);
             const mnMax = parseFloat(r.LifetimeMaxYears);


### PR DESCRIPTION
### Motivation
- The repair scoring masks were empty because the CSV loader read legacy column names (`When (# defects)` / `Where? (road type)`) while the current `RepairStrats.csv` uses `Situation` and `RoadType`, which produced an all-zero `FullRepairMatrix` and thus zero percentages/certainties.

### Description
- Update `loadAllData` in `assets/js/dataLoader.js` to fall back to the active CSV keys by using `groupValues.push(r['When (# defects)'] || r.Situation || '')` and `roadTypes.push(r['Where? (road type)'] || r.RoadType || '')`, restoring proper group/material masks and populated repair matrices.

### Testing
- Ran a Node check that calls `loadAllData('./assets/csv/')` and summed all entries of `FullRepairMatrix`, which returned `480.0000000000015`, indicating the matrix is now populated (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa02c2d41c832e815a437d3b1ba3e1)