### PR TITLE
Improve RoadGP wizard navigation gating and step-1 input sizing

### DIFF
--- a/assets/css/roadgp.css
+++ b/assets/css/roadgp.css
@@ -376,7 +376,6 @@ input.severity-quantity::-webkit-outer-spin-button {
 .step-nav .nav-item.disabled {
     opacity: 0.5;
     cursor: not-allowed;
-    pointer-events: none;
 }
 
 .navigation {

--- a/assets/css/roadgp.css
+++ b/assets/css/roadgp.css
@@ -373,6 +373,12 @@ input.severity-quantity::-webkit-outer-spin-button {
     color: #fff;
 }
 
+.step-nav .nav-item.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 .navigation {
     margin-top: 20px;
     display: flex;
@@ -414,7 +420,7 @@ input.severity-quantity::-webkit-outer-spin-button {
 }
 
 .road-length input {
-    width: 65%;
+    width: 72%;
     max-width: 100%;
     box-sizing: border-box;
     display: block;

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -2,16 +2,50 @@ document.addEventListener('DOMContentLoaded', function () {
     const steps = document.querySelectorAll('.step');
     const navItems = document.querySelectorAll('.nav-item');
     const diagnoseButton = document.getElementById('diagnose-button');
+    const roadLengthInput = document.getElementById('road-length-input');
     let currentStep = 1;
+    let maxReachedStep = 1;
+
+    function hasValidRoadLength() {
+        if (!roadLengthInput) {
+            return true;
+        }
+        const value = parseFloat(roadLengthInput.value);
+        return !isNaN(value) && value > 0;
+    }
+
+    function canAccessStep(targetStep) {
+        if (targetStep <= maxReachedStep) {
+            return true;
+        }
+        if (targetStep === 2) {
+            return hasValidRoadLength();
+        }
+        return false;
+    }
+
+    function updateNavAccessibility() {
+        navItems.forEach((item, idx) => {
+            const stepNumber = idx + 1;
+            const enabled = canAccessStep(stepNumber);
+            item.classList.toggle('disabled', !enabled);
+            item.setAttribute('aria-disabled', String(!enabled));
+            item.setAttribute('tabindex', enabled ? '0' : '-1');
+        });
+    }
 
     function showStep(n) {
         currentStep = n;
+        maxReachedStep = Math.max(maxReachedStep, n);
+
         steps.forEach((step, idx) => {
             step.style.display = idx === n - 1 ? 'block' : 'none';
         });
         navItems.forEach((item, idx) => {
             item.classList.toggle('active', idx === n - 1);
         });
+
+        updateNavAccessibility();
     }
 
     function shouldTriggerDiagnosis(targetStep) {
@@ -19,14 +53,29 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function goToStep(targetStep) {
+        if (!canAccessStep(targetStep)) {
+            return;
+        }
+
         if (shouldTriggerDiagnosis(targetStep) && diagnoseButton) {
             diagnoseButton.click();
             return;
         }
+
         showStep(targetStep);
     }
 
-    document.getElementById('to-step-2').addEventListener('click', () => goToStep(2));
+    document.getElementById('to-step-2').addEventListener('click', () => {
+        if (!hasValidRoadLength()) {
+            if (typeof showWarning === 'function') {
+                showWarning('Please enter a valid road length before continuing.');
+            }
+            roadLengthInput?.focus();
+            return;
+        }
+        goToStep(2);
+    });
+
     document.getElementById('back-to-step-1').addEventListener('click', () => goToStep(1));
     if (diagnoseButton) {
         diagnoseButton.addEventListener('click', () => showStep(3));
@@ -36,7 +85,7 @@ document.addEventListener('DOMContentLoaded', function () {
     navItems.forEach((item, idx) => {
         const targetStep = idx + 1;
         item.setAttribute('role', 'button');
-        item.setAttribute('tabindex', '0');
+
         item.addEventListener('click', () => goToStep(targetStep));
         item.addEventListener('keydown', (event) => {
             if (event.key === 'Enter' || event.key === ' ') {
@@ -55,6 +104,8 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
     });
+
+    roadLengthInput?.addEventListener('input', updateNavAccessibility);
 
     showStep(1);
 });

--- a/assets/js/wizard.js
+++ b/assets/js/wizard.js
@@ -15,11 +15,11 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function canAccessStep(targetStep) {
-        if (targetStep <= maxReachedStep) {
-            return true;
-        }
         if (targetStep === 2) {
             return hasValidRoadLength();
+        }
+        if (targetStep <= maxReachedStep) {
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
### Motivation
- The road length input placeholder was being truncated on desktop and needed a slightly wider input to show the full text.
- Users could jump forward to steps they had not reached yet, which breaks expected sequential wizard behavior and can cause invalid state.
- The navigator needed clearer visual and accessibility feedback for locked steps.

### Description
- Increased the Step 1 road-length input width from `65%` to `72%` in `assets/css/roadgp.css` so the placeholder ("meters") is fully visible on desktop.
- Added a `.step-nav .nav-item.disabled` style to visually indicate locked steps and disable pointer events in `assets/css/roadgp.css`.
- Rewrote the wizard gating in `assets/js/wizard.js` to track `maxReachedStep`, added `hasValidRoadLength()`, `canAccessStep()`, and `updateNavAccessibility()` helper functions, and updated `showStep()` to advance `maxReachedStep` and refresh nav accessibility.
- Prevent forward navigation to future steps unless unlocked, require a valid road length (> 0) to enter Step 2, show a warning and focus the input when attempting to continue without a valid length, and keep Step 3 gated until invoked via the diagnosis flow; also update `aria-disabled` and `tabindex` on nav items for accessibility.

### Testing
- Ran a repository-wide search with `rg -n "RoadGP|road length|Enter road length|step 1|step 2|step 3|navigator|step" .` to locate affected files and confirm references, which succeeded.
- Inspected the intended changes with `git diff -- assets/js/wizard.js assets/css/roadgp.css` to verify only the two target files were modified, which succeeded.
- Opened the modified files with `nl -ba assets/js/wizard.js` and `nl -ba assets/css/roadgp.css` to verify the new logic and styles were present and correct, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa14be35bc832e9894626baa067357)