### PR TITLE
Add road-type metadata and filtering for symptoms and repairs

### DIFF
--- a/assets/js/dataLoader.js
+++ b/assets/js/dataLoader.js
@@ -57,6 +57,25 @@ async function loadAllData(basePath = '../assets/csv/') {
 
     const symptoms = unique(defectRepair.map(r => r.Defect));
 
+    const symptomRoadTypes = symptoms.map(symptom => {
+        const types = new Set();
+        defectRepair.forEach(row => {
+            if (row.Defect !== symptom) return;
+            const roadType = (row.RoadType || '').toLowerCase();
+            if (roadType.includes('asphalt')) types.add('asphalt');
+            if (roadType.includes('concrete')) types.add('concrete');
+            if (roadType.includes('both')) {
+                types.add('asphalt');
+                types.add('concrete');
+            }
+        });
+        if (types.size === 0) {
+            types.add('asphalt');
+            types.add('concrete');
+        }
+        return Array.from(types);
+    });
+
     // Build the canonical cause universe from CauseTreatment by CauseID
     const causeRows = [];
     const seenCause = new Set();
@@ -116,6 +135,7 @@ async function loadAllData(basePath = '../assets/csv/') {
     const costMatrixNamed = [];
     const groupValues = [];
     const roadTypes = [];
+    const repairRoadTypes = [];
     const lifeMean = [];
     const lifeMin = [];
     const lifeMax = [];
@@ -132,7 +152,13 @@ async function loadAllData(basePath = '../assets/csv/') {
             repairStrategyGroups.push(r.Category);
             costMatrixNamed.push(r.Cost);
             groupValues.push(r['When (# defects)'] || r.Situation || '');
-            roadTypes.push(r['Where? (road type)'] || r.RoadType || '');
+            const roadTypeValue = r['Where? (road type)'] || r.RoadType || '';
+            roadTypes.push(roadTypeValue);
+            const normalizedRoadType = roadTypeValue.toLowerCase();
+            const supportedTypes = [];
+            if (normalizedRoadType.includes('asphalt') || normalizedRoadType.includes('both')) supportedTypes.push('asphalt');
+            if (normalizedRoadType.includes('concrete') || normalizedRoadType.includes('both')) supportedTypes.push('concrete');
+            repairRoadTypes.push(supportedTypes.length ? supportedTypes : ['asphalt', 'concrete']);
             const mn = parseFloat(r.LifetimeMean);
             const mnMin = parseFloat(r.LifetimeMinYears);
             const mnMax = parseFloat(r.LifetimeMaxYears);
@@ -364,6 +390,8 @@ async function loadAllData(basePath = '../assets/csv/') {
             // Repairs
             repairStrategies,
             repairStrategyGroups,
+            repairRoadTypes,
+            symptomRoadTypes,
             timeSync: lifeMean
         },
         // Defect→Cause

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -211,7 +211,6 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     function applySymptomFilters() {
         const allowed = getAllowedSymptoms();
-        currentList = allowed.length ? allowed : [];
         filterSymptomButtons(allowed);
 
         [...selectedSymptoms.children].forEach(el => {
@@ -223,7 +222,6 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     // ————— Hook up the SVG click-zones —————
     let currentRegion = null;
-    let currentList = data.symptoms;
     const svgRegions = document.querySelectorAll("#road-selector svg g[id]");
 
     function clearActiveRegion() {

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -467,6 +467,9 @@ document.addEventListener("DOMContentLoaded", async function () {
         const sentence2     = `Which is traditionally treated by ${traditional}.`;
     
         // 3) Repairs sentence
+        if (!topRepIdx.length) {
+            return [ sentence1, sentence2, 'No repair data is available for the selected material and defect/severity combination.' ];
+        }
         const repNames     = topRepIdx.map(i=> data.repairStrategies[i]).join(" or ");
         const secondRepRel = Math.max(...repairRel.filter((v,i)=>i!==topRepIdx[0]));
         const sentence3 = `${repairPrefix} ${repNames}.`;
@@ -563,7 +566,9 @@ document.addEventListener("DOMContentLoaded", async function () {
         picked.topRepIdx = picked.topRepIdx.filter(i => allowedRepairSet.has(i));
         if (!picked.topRepIdx.length && allowedRepairIndices.length) {
             const maxAllowedPct = Math.max(...allowedRepairIndices.map(i => analysis.repairPct[i]));
-            picked.topRepIdx = allowedRepairIndices.filter(i => analysis.repairPct[i] === maxAllowedPct);
+            if (maxAllowedPct > 0) {
+                picked.topRepIdx = allowedRepairIndices.filter(i => analysis.repairPct[i] === maxAllowedPct);
+            }
         }
         // const summary  = makeSummary(selected, analysis, picked);
         const summary  = makeSummary(entries, analysis, picked);

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -567,7 +567,15 @@ document.addEventListener("DOMContentLoaded", async function () {
         if (!picked.topRepIdx.length && allowedRepairIndices.length) {
             const maxAllowedPct = Math.max(...allowedRepairIndices.map(i => analysis.repairPct[i]));
             if (maxAllowedPct > 0) {
-                picked.topRepIdx = allowedRepairIndices.filter(i => analysis.repairPct[i] === maxAllowedPct);
+                let fallback = allowedRepairIndices.filter(i => analysis.repairPct[i] === maxAllowedPct);
+                // apply same tie-breakers as pickTop: cheapest → longest life → smallest range
+                const minCost = Math.min(...fallback.map(i => costRank[i]));
+                fallback = fallback.filter(i => costRank[i] === minCost);
+                const maxLife = Math.max(...fallback.map(i => lifeMean[i]));
+                fallback = fallback.filter(i => lifeMean[i] === maxLife);
+                const minRange = Math.min(...fallback.map(i => Math.abs(lifeRange[i])));
+                fallback = fallback.filter(i => Math.abs(lifeRange[i]) === minRange);
+                picked.topRepIdx = fallback;
             }
         }
         // const summary  = makeSummary(selected, analysis, picked);

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -121,7 +121,7 @@ document.addEventListener("DOMContentLoaded", async function () {
             autocompleteList.style.display = "none";
             return;
         }
-        let matches = data.symptoms.filter(symptom => symptom.toLowerCase().includes(value));
+        let matches = getAllowedSymptoms().filter(symptom => symptom.toLowerCase().includes(value));
         matches.forEach(symptom => {
             let item = document.createElement("div");
             item.className = "autocomplete-item";
@@ -194,6 +194,33 @@ document.addEventListener("DOMContentLoaded", async function () {
         });
     }
 
+
+    function getMaterialAllowedSymptoms(material = getSelectedMaterial()) {
+        return data.symptoms.filter((symptom, idx) => {
+            const roadTypes = data.symptomRoadTypes?.[idx] || ['asphalt', 'concrete'];
+            return roadTypes.includes(material);
+        });
+    }
+
+    function getAllowedSymptoms() {
+        const byMaterial = getMaterialAllowedSymptoms();
+        if (!currentRegion) return byMaterial;
+        const byRegion = regionToSymptoms[currentRegion] || [];
+        return byRegion.filter(symptom => byMaterial.includes(symptom));
+    }
+
+    function applySymptomFilters() {
+        const allowed = getAllowedSymptoms();
+        currentList = allowed.length ? allowed : [];
+        filterSymptomButtons(allowed);
+
+        [...selectedSymptoms.children].forEach(el => {
+            if (!allowed.includes(el.dataset.symptom)) {
+                el.remove();
+            }
+        });
+    }
+
     // ————— Hook up the SVG click-zones —————
     let currentRegion = null;
     let currentList = data.symptoms;
@@ -212,34 +239,50 @@ document.addEventListener("DOMContentLoaded", async function () {
         const isTogglingOff = currentRegion === region;
         if (isTogglingOff) {
             currentRegion = null;
-            currentList = data.symptoms;
             clearActiveRegion();
-            filterSymptomButtons(currentList);
+            applySymptomFilters();
             return;
         }
 
-        const list = regionToSymptoms[region] || [];
         currentRegion = region;
-        currentList = list.length ? list : data.symptoms;
 
         clearActiveRegion();
         regionEl.classList.add("active");
 
-        filterSymptomButtons(currentList);
+        applySymptomFilters();
         });
     });
 
 
+    document.querySelectorAll('input[name="road-material"]').forEach(inputEl => {
+        inputEl.addEventListener('change', () => {
+            applySymptomFilters();
+            autocompleteList.style.display = 'none';
+        });
+    });
+
     const step2Btn = document.getElementById('to-step-2');
     if (step2Btn) {
         step2Btn.addEventListener('click', () => {
-            filterSymptomButtons(currentList.length ? currentList : data.symptoms);
+            applySymptomFilters();
         });
     }
+
+    applySymptomFilters();
 
     function getSelectedMaterial() {
         const mat = document.querySelector('input[name="road-material"]:checked');
         return mat ? mat.value.toLowerCase() : 'asphalt';
+    }
+
+
+    function getAllowedRepairIndices(material = getSelectedMaterial()) {
+        return data.repairStrategies
+            .map((_, idx) => idx)
+            .filter(idx => {
+                const roadTypes = data.repairRoadTypes?.[idx] || ['asphalt', 'concrete'];
+                return roadTypes.includes(material);
+            });
     }
 
     function getRepairVector(material, symptomIndex, severity, quantity) {
@@ -517,6 +560,13 @@ document.addEventListener("DOMContentLoaded", async function () {
         const material = getSelectedMaterial();
         const analysis = analyze(entries, material);
         const picked   = pickTop(analysis);
+        const allowedRepairIndices = getAllowedRepairIndices(material);
+        const allowedRepairSet = new Set(allowedRepairIndices);
+        picked.topRepIdx = picked.topRepIdx.filter(i => allowedRepairSet.has(i));
+        if (!picked.topRepIdx.length && allowedRepairIndices.length) {
+            const maxAllowedPct = Math.max(...allowedRepairIndices.map(i => analysis.repairPct[i]));
+            picked.topRepIdx = allowedRepairIndices.filter(i => analysis.repairPct[i] === maxAllowedPct);
+        }
         // const summary  = makeSummary(selected, analysis, picked);
         const summary  = makeSummary(entries, analysis, picked);
 
@@ -539,7 +589,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         // 1) Put the chosen top repairs (from pickTop) first (preserving their order)
         // 2) Append the remaining repairs sorted by percentage desc
 
-        const allRepairIdx = [...Array(data.repairStrategies.length).keys()];
+        const allRepairIdx = getAllowedRepairIndices(material);
         const topRepIdxSet = new Set(picked.topRepIdx);
 
         // indices not in the top set


### PR DESCRIPTION
### Motivation
- Make the symptom/repair selection aware of road material and region so users only see applicable defects and repairs for `asphalt` vs `concrete` contexts.
- Populate canonical road-type support from CSV so the UI can filter autocomplete, symptom buttons, and repair lists by material and selected SVG region.

### Description
- Extend `loadAllData` to compute and return `symptomRoadTypes` and `repairRoadTypes` by normalizing CSV `RoadType`/`Where? (road type)` values and defaulting to both `asphalt` and `concrete` when unspecified.
- Add UI helper functions `getMaterialAllowedSymptoms`, `getAllowedSymptoms`, `applySymptomFilters`, and `getAllowedRepairIndices` and wire them into autocomplete, symptom button filtering, region click handlers, material radio change events, and initial page setup.
- Filter diagnosis results so `picked.topRepIdx` and the final repair ordering respect allowed repair indices for the selected material, and fall back to the best allowed repairs when the original picks are disallowed.
- Ensure symptom controls currently selected are removed if they become disallowed by a material or region change, and hide the autocomplete when material changes.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa198b7f24832eaca38f41ba00885c)