### PR TITLE
Populate TRA 2026 supplementary page with poster, figures, and project links

### DIFF
--- a/pages/tra2026.html
+++ b/pages/tra2026.html
@@ -25,12 +25,12 @@
                     <span class="material-status">Open PDF</span>
                 </a>
 
-                <a class="material-link" href="https://miro.com/app/board/uXjVGvHMaE4=/?focusWidget=3458764664962423566&embedMode=view_only_without_ui&embedId=375699585748" target="_blank" rel="noopener noreferrer">
+                <a class="material-link" href="https://miro.com/app/board/uXjVGvHMaE4=/?focusWidget=3458764664962423566&amp;embedMode=view_only_without_ui&amp;embedId=375699585748" target="_blank" rel="noopener noreferrer">
                     <span class="material-title">Figure 7 (Full Size)</span>
                     <span class="material-status">Open Miro Board View</span>
                 </a>
 
-                <a class="material-link" href="https://miro.com/app/board/uXjVGvHMaE4=/?focusWidget=3458764641566650049&embedMode=view_only_without_ui&embedId=101390985169" target="_blank" rel="noopener noreferrer">
+                <a class="material-link" href="https://miro.com/app/board/uXjVGvHMaE4=/?focusWidget=3458764641566650049&amp;embedMode=view_only_without_ui&amp;embedId=101390985169" target="_blank" rel="noopener noreferrer">
                     <span class="material-title">Figure 8 (Full Size)</span>
                     <span class="material-status">Open Miro Board View</span>
                 </a>

--- a/pages/tra2026.html
+++ b/pages/tra2026.html
@@ -16,23 +16,33 @@
             <h1 id="supplementary-title">RoadGP Supplementary Materials</h1>
             <p class="intro-text">
                 Thank you for visiting our poster. Please use the links below to access the poster PDF,
-                the full diagram, and the RoadGP tool.
+                full-size versions of Figures 7 and 8, try the RoadGP tool, and read more details on how it works and how to use it.
             </p>
 
             <div class="materials-list">
-                <a class="material-link placeholder" href="#" aria-disabled="true" onclick="return false;">
+                <a class="material-link" href="/assets/pdf/TRA_2026_poster_RoadGP.pdf" target="_blank" rel="noopener noreferrer">
                     <span class="material-title">Electronic Poster (PDF)</span>
-                    <span class="material-status">Link will be added soon</span>
+                    <span class="material-status">Open PDF</span>
                 </a>
 
-                <a class="material-link placeholder" href="#" aria-disabled="true" onclick="return false;">
-                    <span class="material-title">Full Diagram (Unclipped View)</span>
-                    <span class="material-status">Link will be added soon</span>
+                <a class="material-link" href="https://miro.com/app/board/uXjVGvHMaE4=/?focusWidget=3458764664962423566&embedMode=view_only_without_ui&embedId=375699585748" target="_blank" rel="noopener noreferrer">
+                    <span class="material-title">Figure 7 (Full Size)</span>
+                    <span class="material-status">Open Miro Board View</span>
+                </a>
+
+                <a class="material-link" href="https://miro.com/app/board/uXjVGvHMaE4=/?focusWidget=3458764641566650049&embedMode=view_only_without_ui&embedId=101390985169" target="_blank" rel="noopener noreferrer">
+                    <span class="material-title">Figure 8 (Full Size)</span>
+                    <span class="material-status">Open Miro Board View</span>
                 </a>
 
                 <a class="material-link" href="/pages/roadgp.html">
-                    <span class="material-title">Open the RoadGP Tool</span>
-                    <span class="material-status">Available now</span>
+                    <span class="material-title">Try the RoadGP Tool</span>
+                    <span class="material-status">Open Interactive Demo</span>
+                </a>
+
+                <a class="material-link" href="https://drf.eng.cam.ac.uk/research/road-gp-v10-road-defect-diagnosis-tool" target="_blank" rel="noopener noreferrer">
+                    <span class="material-title">RoadGP Tool Details and Usage (Project Website)</span>
+                    <span class="material-status">Learn More</span>
                 </a>
             </div>
 


### PR DESCRIPTION
### Motivation
- Make the TRA 2026 supplementary page actionable by replacing placeholder entries with real assets so visitors can open the poster, view full-size figures, try the interactive demo, and read project details. 

### Description
- Updated `pages/tra2026.html` copy to mention full-size Figures 7 and 8, the RoadGP tool, and detailed project information. 
- Replaced placeholder anchors with a PDF link to `../assets/pdf/TRA_2026_poster_RoadGP.pdf`, Miro links for Figure 7 and Figure 8, and an external project details link to `https://drf.eng.cam.ac.uk/research/road-gp-v10-road-defect-diagnosis-tool`, adding `target="_blank"` and `rel="noopener noreferrer"` where appropriate. 
- Updated the RoadGP demo entry to link to the local demo page at `/pages/roadgp.html` and adjusted link labels/status text accordingly; removed `aria-disabled`/`onclick` placeholder attributes. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4fd65108832e82a68baaff032aee)