### PR TITLE
Organize Step 2 defect selection and add SVG category hover labels

### DIFF
--- a/assets/css/roadgp.css
+++ b/assets/css/roadgp.css
@@ -567,6 +567,7 @@ input.severity-quantity::-webkit-outer-spin-button {
 
 .symptom-group {
     margin-top: 10px;
+    width: 100%;
 }
 
 .symptom-group-heading {

--- a/assets/css/roadgp.css
+++ b/assets/css/roadgp.css
@@ -564,3 +564,49 @@ input.severity-quantity::-webkit-outer-spin-button {
     margin-bottom: 12px;
     font-size: 0.95rem;
 }
+
+.symptom-group {
+    margin-top: 10px;
+}
+
+.symptom-group-heading {
+    margin: 8px 0;
+    font-size: 1rem;
+    color: #2b2b2b;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 4px;
+}
+
+.symptom-group.selected .symptom-group-heading {
+    color: #0056b3;
+    border-bottom-color: #007BFF;
+}
+
+.symptom-group-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+#road-selector {
+    position: relative;
+}
+
+.svg-hover-tooltip {
+    position: absolute;
+    pointer-events: none;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    opacity: 0;
+    transform: translateY(-4px);
+    transition: opacity 0.12s ease;
+    z-index: 15;
+    white-space: nowrap;
+}
+
+.svg-hover-tooltip.visible {
+    opacity: 1;
+}

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -264,7 +264,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     const svgTooltip = document.createElement("div");
     svgTooltip.className = "svg-hover-tooltip";
-    svgTooltip.setAttribute("role", "status");
+    svgTooltip.setAttribute("aria-hidden", "true");
     roadSelector.appendChild(svgTooltip);
 
     function updateSvgTooltip(event, region) {

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -53,6 +53,13 @@ document.addEventListener("DOMContentLoaded", async function () {
         return topRegion;
     }
 
+    const regionLabels = {
+        pavement: "Pavement",
+        markings: "Markings",
+        gully: "Drainage / Gully",
+        unclassified: "Other Defects"
+    };
+
     function buildRegionToSymptoms(symptoms) {
         const mapping = { pavement: [], markings: [], gully: [] };
         const unclassified = [];
@@ -102,15 +109,41 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     const seenEntries = new Set();     // symptom|severity as key
 
-    // Populate symptom buttons for quick selection  
-    data.symptoms.forEach(symptom => {
-        let button = document.createElement("div");
-        button.className = "symptom-button";
-        button.textContent = symptom;
-        button.onclick = () => addSymptom(symptom);
-        symptomButtons.appendChild(button);
-    });
+    function renderSymptomGroups() {
+        symptomButtons.innerHTML = "";
 
+        const regionOrder = ["pavement", "markings", "gully", "unclassified"];
+        regionOrder.forEach(region => {
+            const symptoms = regionToSymptoms[region] || [];
+            if (!symptoms.length) return;
+
+            const group = document.createElement("section");
+            group.className = "symptom-group";
+            group.dataset.region = region;
+
+            const heading = document.createElement("h3");
+            heading.className = "symptom-group-heading";
+            heading.textContent = regionLabels[region] || region;
+            group.appendChild(heading);
+
+            const list = document.createElement("div");
+            list.className = "symptom-group-list";
+
+            symptoms.forEach(symptom => {
+                const button = document.createElement("div");
+                button.className = "symptom-button";
+                button.textContent = symptom;
+                button.dataset.region = region;
+                button.onclick = () => addSymptom(symptom);
+                list.appendChild(button);
+            });
+
+            group.appendChild(list);
+            symptomButtons.appendChild(group);
+        });
+    }
+
+    renderSymptomGroups();
     filterSymptomButtons(data.symptoms);  // default to showing all defects
 
     // Autocomplete function
@@ -188,9 +221,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     function filterSymptomButtons(allowedList) {
         document.querySelectorAll(".symptom-button").forEach(btn => {
           const name = btn.textContent;
-          btn.style.display = allowedList.includes(name)
-            ? "inline-block"
-            : "none";
+          btn.style.display = allowedList.includes(name) ? "inline-block" : "none";
+        });
+
+        document.querySelectorAll(".symptom-group").forEach(group => {
+            const visibleCount = group.querySelectorAll('.symptom-button[style*="inline-block"], .symptom-button:not([style])').length;
+            group.style.display = visibleCount ? "block" : "none";
+            group.classList.toggle("selected", !!currentRegion && group.dataset.region === currentRegion);
         });
     }
 
@@ -223,6 +260,24 @@ document.addEventListener("DOMContentLoaded", async function () {
     // ————— Hook up the SVG click-zones —————
     let currentRegion = null;
     const svgRegions = document.querySelectorAll("#road-selector svg g[id]");
+    const roadSelector = document.getElementById("road-selector");
+
+    const svgTooltip = document.createElement("div");
+    svgTooltip.className = "svg-hover-tooltip";
+    svgTooltip.setAttribute("role", "status");
+    roadSelector.appendChild(svgTooltip);
+
+    function updateSvgTooltip(event, region) {
+        svgTooltip.textContent = regionLabels[region] || region;
+        const rect = roadSelector.getBoundingClientRect();
+        svgTooltip.style.left = `${event.clientX - rect.left + 8}px`;
+        svgTooltip.style.top = `${event.clientY - rect.top + 8}px`;
+        svgTooltip.classList.add("visible");
+    }
+
+    function hideSvgTooltip() {
+        svgTooltip.classList.remove("visible");
+    }
 
     function clearActiveRegion() {
         svgRegions.forEach(el => el.classList.remove("active"));
@@ -230,6 +285,9 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     svgRegions.forEach(regionEl => {
         regionEl.style.cursor = "pointer";
+        regionEl.setAttribute("aria-label", regionLabels[regionEl.id] || regionEl.id);
+        regionEl.addEventListener("mousemove", (event) => updateSvgTooltip(event, regionEl.id));
+        regionEl.addEventListener("mouseleave", hideSvgTooltip);
         regionEl.addEventListener("click", () => {
         const region = regionEl.id;    // "markings", "gully", "pavement"
 
@@ -239,6 +297,7 @@ document.addEventListener("DOMContentLoaded", async function () {
             currentRegion = null;
             clearActiveRegion();
             applySymptomFilters();
+            hideSvgTooltip();
             return;
         }
 
@@ -248,6 +307,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         regionEl.classList.add("active");
 
         applySymptomFilters();
+        hideSvgTooltip();
         });
     });
 
@@ -263,6 +323,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (step2Btn) {
         step2Btn.addEventListener('click', () => {
             applySymptomFilters();
+        hideSvgTooltip();
         });
     }
 

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -101,6 +101,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     const symptomButtons = document.getElementById("symptom-buttons");
     const selectedSymptoms = document.getElementById("selected-symptoms");
+    let currentRegion = null;
     const input = document.getElementById("symptom-input");
     const autocompleteList = document.getElementById("autocomplete-list");
     const resultsContainer = document.getElementById("results");
@@ -258,7 +259,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
 
     // ————— Hook up the SVG click-zones —————
-    let currentRegion = null;
     const svgRegions = document.querySelectorAll("#road-selector svg g[id]");
     const roadSelector = document.getElementById("road-selector");
 

--- a/assets/js/roadgp.js
+++ b/assets/js/roadgp.js
@@ -323,7 +323,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (step2Btn) {
         step2Btn.addEventListener('click', () => {
             applySymptomFilters();
-        hideSvgTooltip();
+            hideSvgTooltip();
         });
     }
 


### PR DESCRIPTION
### Motivation
- Improve Step 2 usability by presenting defects grouped by asset category instead of a single flat list so users can scan options quickly. 
- Keep context when a user filters by clicking the SVG by preserving and visually emphasising the selected category heading. 
- Provide immediate feedback when hovering the SVG by showing the asset category name as a small hover card.

### Description
- Added a `regionLabels` map and a `renderSymptomGroups()` function in `assets/js/roadgp.js` to render defects under category headings (`Pavement`, `Markings`, `Drainage / Gully`, and fallback `Other Defects`).
- Updated `filterSymptomButtons()` to hide empty groups and toggle a `selected` class on the matching category section when an SVG region is active so the heading remains highlighted.
- Injected an SVG hover tooltip DOM node (`.svg-hover-tooltip`) and wired `mousemove`, `mouseleave`, and click handlers on `#road-selector svg g[id]` to show/hide the category label and set `aria-label` for accessibility in `assets/js/roadgp.js`.
- Added supporting CSS in `assets/css/roadgp.css` for `.symptom-group`, `.symptom-group-heading`, `.symptom-group.selected`, `.symptom-group-list`, `#road-selector` positioning and `.svg-hover-tooltip` styling.
- Preserved existing filtering and selection behavior (clicking an active region still clears the filter and restores all applicable defects).

### Testing
- Ran a syntax check with `node --check assets/js/roadgp.js` which completed successfully.
- Verified working tree status via `git status --short` during development and committed the changes locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde0ac2ac8832e8c7afcb027d43fcd)